### PR TITLE
fixed selector for mute button

### DIFF
--- a/ext/js/meetmute.js
+++ b/ext/js/meetmute.js
@@ -1,4 +1,4 @@
-const MUTE_BUTTON = 'div[role="button"][aria-label*="microphone"][data-is-muted]'
+const MUTE_BUTTON = 'div[role="button"][aria-label][data-is-muted]'
 
 const waitUntilElementExists = (DOMSelector, MAX_TIME = 5000) => {
   let timeout = 0


### PR DESCRIPTION
Initial selector includes English text of the Mute button, but it's localised and in different languages it contains different texts so it's better to find the first element with attribute 'aria-label' and it's a Mute button.