### PR TITLE
Update mute query selector for new UI.

### DIFF
--- a/ext/js/meetmute.js
+++ b/ext/js/meetmute.js
@@ -1,4 +1,4 @@
-const MUTE_BUTTON = 'div[role="button"][aria-label][data-is-muted]'
+const MUTE_BUTTON = '[role="button"][aria-label][data-is-muted]'
 
 const waitUntilElementExists = (DOMSelector, MAX_TIME = 5000) => {
   let timeout = 0


### PR DESCRIPTION
Google is rolling out a new Meet UI. The mute div has become a button.

See https://cloud.google.com/blog/products/google-meet/new-features-for-google-meet

This change is meant to work on both the old and new version as they are
both still live.

Tested manually on both versions of Meet.