### PR TITLE
Click the mute button rather than using key shortcut

### DIFF
--- a/ext/js/meetmute.js
+++ b/ext/js/meetmute.js
@@ -96,31 +96,22 @@ chrome.runtime.onMessage.addListener(
     muted = isMuted()
     if (request && request.command && request.command === 'toggle_mute') {
       muted = !muted
-      sendKeyboardCommand()
+      toggleMeetMuted();
     } else if (request && request.command && request.command === 'mute') {
       if (!muted) {
         muted = !muted
-        sendKeyboardCommand()
+        toggleMeetMuted();
       }
     } else if (request && request.command && request.command === 'unmute') {
       if (muted) {
         muted = !muted
-        sendKeyboardCommand()
+        toggleMeetMuted();
       }
     }
 
     sendResponse({ message: muted ? 'muted' : 'unmuted' });
   })
 
-const keydownEvent = new KeyboardEvent('keydown', {
-  "key": "d",
-  "code": "KeyD",
-  "metaKey": true,
-  "charCode": 100,
-  "keyCode": 100,
-  "which": 100
-})
-
-function sendKeyboardCommand() {
-  document.dispatchEvent(keydownEvent)
+function toggleMeetMuted() {
+  document.querySelector(MUTE_BUTTON).click();
 }


### PR DESCRIPTION
It appears as though key shortcuts might vary across
platforms. The previous method of toggling mute was
to press META+d, which is Command+d on MacOS, but ends
up being WindowsKey+d on Windows or Linux PCs for the
most part, which doesn't match the CTRL+d shortcut
that meet wants when running on those systems.

Rather than trying to figure out the underlying system
to guess the correct keybindings, or just risking more
issues later if Google decides to update they key shortcut,
just have the extension click the mute button, since it
already has a selector for it that is required for it to
function correctly.